### PR TITLE
Exclude :while_executing from unique retries

### DIFF
--- a/lib/sidekiq_unique_retries/adapters/sidekiq_unique_jobs.rb
+++ b/lib/sidekiq_unique_retries/adapters/sidekiq_unique_jobs.rb
@@ -1,12 +1,19 @@
 module SidekiqUniqueRetries
   module Adapters
     class SidekiqUniqueJobs
+      UNIQUE_RETRY_LOCKS = %w[
+        until_executing
+        until_executed
+        until_timeout
+        until_and_while_executing
+      ].freeze
 
       JOB_ID_KEY = 'jid'.freeze
-      UNIQUE_DIGEST_KEY = 'unique_digest'.freeze
+      LOCK_KEY = 'unique'.freeze
+      DIGEST_KEY = 'unique_digest'.freeze
 
       def lockable?(item)
-        item.key?(UNIQUE_DIGEST_KEY)
+        UNIQUE_RETRY_LOCKS.include?(item[LOCK_KEY])
       end
 
       def job_id(item)
@@ -14,9 +21,8 @@ module SidekiqUniqueRetries
       end
 
       def unique_digest(item)
-        item.fetch(UNIQUE_DIGEST_KEY)
+        item.fetch(DIGEST_KEY)
       end
-
     end
   end
 end

--- a/lib/sidekiq_unique_retries/extensions/api.rb
+++ b/lib/sidekiq_unique_retries/extensions/api.rb
@@ -3,7 +3,6 @@ require 'sidekiq/api'
 module SidekiqUniqueRetries
   module Extensions
     module SortedEntry
-
       def delete
         if SidekiqUniqueRetries.lockable?(item)
           SidekiqUniqueRetries.unlock(item)
@@ -27,7 +26,6 @@ module SidekiqUniqueRetries
 
         super
       end
-
     end
   end
 end

--- a/lib/sidekiq_unique_retries/lock.rb
+++ b/lib/sidekiq_unique_retries/lock.rb
@@ -48,5 +48,4 @@ module SidekiqUniqueRetries
       end
     end
   end
-
 end

--- a/sidekiq_unique_retries.gemspec
+++ b/sidekiq_unique_retries.gemspec
@@ -19,9 +19,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "sidekiq", ">= 5.0.0"
+  spec.add_dependency "sidekiq", "~> 5.2"
 
-  spec.add_development_dependency "bundler", "~> 1.15"
+  spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/spec/sidekiq_unique_retries/extensions/api_spec.rb
+++ b/spec/sidekiq_unique_retries/extensions/api_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'Sidekiq api' do
       'class' => 'Foo',
       'args' => [101],
       'jid' => 'jid_0',
+      'unique' => 'until_executed',
       'unique_digest' => 'uniquejobs:b'
     }
   end
@@ -63,5 +64,4 @@ RSpec.describe 'Sidekiq api' do
       end
     end
   end
-
 end

--- a/spec/sidekiq_unique_retries/extensions/processor_spec.rb
+++ b/spec/sidekiq_unique_retries/extensions/processor_spec.rb
@@ -3,15 +3,17 @@ require 'spec_helper'
 require 'sidekiq/processor'
 
 RSpec.describe Sidekiq::Processor do
-  let(:processor) { described_class.new(manager) }
-  let(:manager) { Struct.new(:options).new(manager_options) }
-  let(:manager_options) do
-    {
+  let(:processor) do
+    described_class.new(manager)
+  end
+  let(:manager) do
+    Struct.new(:options).new(
       queues: ['test']
-    }
+    )
   end
 
   let(:initial_lock_hash) { nil }
+
   let(:lock_hash) { $redis.hgetall('bg:uniqueretries') }
 
   before do
@@ -28,9 +30,11 @@ RSpec.describe Sidekiq::Processor do
 
     context 'single job' do
       let(:job_options) { {} }
+
       before do
         DivisionJob.set(
           {
+            unique: 'until_executed',
             unique_digest: 'digest1',
             jid: 'jid1',
             retry: 5
@@ -50,6 +54,7 @@ RSpec.describe Sidekiq::Processor do
             'retry_count' => 0,
             'queue' => 'test',
             'jid' => 'jid1',
+            'unique' => 'until_executed',
             'unique_digest' => 'digest1',
             'error_class' => 'ZeroDivisionError',
             'error_message' => 'divided by 0'
@@ -100,6 +105,7 @@ RSpec.describe Sidekiq::Processor do
               'retry_count' => 4,
               'queue' => 'test',
               'jid' => 'jid1',
+              'unique' => 'until_executed',
               'unique_digest' => 'digest1',
               'error_class' => 'ZeroDivisionError',
               'error_message' => 'divided by 0'
@@ -125,6 +131,7 @@ RSpec.describe Sidekiq::Processor do
               'retry_count' => 5,
               'queue' => 'test',
               'jid' => 'jid1',
+              'unique' => 'until_executed',
               'unique_digest' => 'digest1',
               'error_class' => 'ZeroDivisionError',
               'error_message' => 'divided by 0',
@@ -138,21 +145,25 @@ RSpec.describe Sidekiq::Processor do
     context 'multiple jpbs' do
       it 'puts only one unique jobs into retries set' do
         DivisionJob.set(
+          unique: 'until_executed',
           unique_digest: 'digest1',
           jid: 'jid1',
           retry: 1
         ).perform_async(1, 0)
         DivisionJob.set(
+          unique: 'until_executed',
           unique_digest: 'digest1',
           jid: 'jid2',
           retry: 1
         ).perform_async(2, 0)
         DivisionJob.set(
+          unique: 'until_executed',
           unique_digest: 'digest2',
           jid: 'jid3',
           retry: 1
         ).perform_async(3, 0)
         DivisionJob.set(
+          unique: 'until_executed',
           unique_digest: 'digest2',
           jid: 'jid4',
           retry: 1
@@ -171,6 +182,7 @@ RSpec.describe Sidekiq::Processor do
           'retry' => 1,
           'retry_count' => 0,
           'queue' => 'test',
+          'unique' => 'until_executed',
           'unique_digest' => 'digest1',
           'error_class' => 'ZeroDivisionError',
           'error_message' => 'divided by 0'
@@ -187,6 +199,7 @@ RSpec.describe Sidekiq::Processor do
           'retry' => 1,
           'retry_count' => 0,
           'queue' => 'test',
+          'unique' => 'until_executed',
           'unique_digest' => 'digest1',
           'error_class' => 'ZeroDivisionError',
           'error_message' => 'divided by 0'
@@ -203,6 +216,7 @@ RSpec.describe Sidekiq::Processor do
           'retry' => 1,
           'retry_count' => 0,
           'queue' => 'test',
+          'unique' => 'until_executed',
           'unique_digest' => 'digest1',
           'error_class' => 'ZeroDivisionError',
           'error_message' => 'divided by 0'
@@ -214,6 +228,7 @@ RSpec.describe Sidekiq::Processor do
           'retry' => 1,
           'retry_count' => 0,
           'queue' => 'test',
+          'unique' => 'until_executed',
           'unique_digest' => 'digest2',
           'error_class' => 'ZeroDivisionError',
           'error_message' => 'divided by 0'
@@ -230,6 +245,7 @@ RSpec.describe Sidekiq::Processor do
           'retry' => 1,
           'retry_count' => 0,
           'queue' => 'test',
+          'unique' => 'until_executed',
           'unique_digest' => 'digest1',
           'error_class' => 'ZeroDivisionError',
           'error_message' => 'divided by 0'
@@ -241,6 +257,7 @@ RSpec.describe Sidekiq::Processor do
           'retry' => 1,
           'retry_count' => 0,
           'queue' => 'test',
+          'unique' => 'until_executed',
           'unique_digest' => 'digest2',
           'error_class' => 'ZeroDivisionError',
           'error_message' => 'divided by 0'

--- a/spec/sidekiq_unique_retries/lock_spec.rb
+++ b/spec/sidekiq_unique_retries/lock_spec.rb
@@ -3,54 +3,55 @@ require 'spec_helper'
 RSpec.describe SidekiqUniqueRetries do
 
   describe '.lockable?' do
-    let(:item0) do
-      {
-        'jid' => 'testjob0'
-      }
-    end
-    let(:item10) do
-      {
-        'jid' => 'testjob10',
-        'unique_digest' => 'uniquejobs:abcdef1'
-      }
-    end
-    let(:item11) do
-      {
-        'jid' => 'testjob11',
-        'unique_digest' => 'uniquejobs:abcdef1'
-      }
-    end
-    let(:item20) do
-      {
-        'jid' => 'testjob20',
-        'unique_digest' => 'uniquejobs:abcdef2'
-      }
-    end
-    let(:item21) do
-      {
-        'jid' => 'testjob21',
-        'unique_digest' => 'uniquejobs:abcdef2'
-      }
+    subject { described_class.lockable?(item) }
+
+    context 'item with jid only' do
+      let(:item) do
+        {
+          'jid' => 'testjob0'
+        }
+      end
+
+      specify { is_expected.to eq false }
     end
 
-    specify do
-      expect(described_class.lockable?(item0)).to eq false
-    end
+    context 'item with unique key' do
+      let(:item) do
+        {
+          'jid' => 'testjob0',
+          'unique' => unique
+        }
+      end
 
-    specify do
-      expect(described_class.lockable?(item10)).to eq true
-    end
+      context 'unique: while_executing' do
+        let(:unique) { 'while_executing' }
 
-    specify do
-      expect(described_class.lockable?(item11)).to eq true
-    end
+        specify  { is_expected.to eq false }
+      end
 
-    specify do
-      expect(described_class.lockable?(item20)).to eq true
-    end
+      context 'unique until_executing' do
+        let(:unique) { 'until_executing' }
 
-    specify do
-      expect(described_class.lockable?(item21)).to eq true
+        specify  { is_expected.to eq true }
+      end
+
+      context 'unique: until_executed' do
+        let(:unique) { 'until_executed' }
+
+        specify  { is_expected.to eq true }
+      end
+
+      context 'unique: until_timeout' do
+        let(:unique) { 'until_timeout' }
+
+        specify  { is_expected.to eq true }
+      end
+
+      context 'unique: until_and_while_executing' do
+        let(:unique) { 'until_and_while_executing' }
+
+        specify  { is_expected.to eq true }
+      end
     end
   end
 


### PR DESCRIPTION
`while_executing` is not really unique locking so we don't need unique retries for this type of lock

https://github.com/mhenrixon/sidekiq-unique-jobs/tree/v5.x#locking